### PR TITLE
save temp subTasks into rootTasks

### DIFF
--- a/lib/beelzebub.js
+++ b/lib/beelzebub.js
@@ -129,7 +129,7 @@ class Beelzebub {
     if (tasks.$isRoot()) {
       // transfer all the current subTasks from old _rootTasks to current
 
-      tasks._subTasks = this._rootTasks.$getSubTasks();
+      tasks.$setSubTasks(this._rootTasks.$getSubTasks());
       this._rootTasks = tasks;
 
       return tasks.$register().then((results) => {

--- a/lib/beelzebub.js
+++ b/lib/beelzebub.js
@@ -129,7 +129,7 @@ class Beelzebub {
     if (tasks.$isRoot()) {
       // transfer all the current subTasks from old _rootTasks to current
 
-      tasks.$setSubTask(this._rootTasks.$getSubTask());
+      tasks._subTasks = this._rootTasks.$getSubTasks();
       this._rootTasks = tasks;
 
       return tasks.$register().then((results) => {


### PR DESCRIPTION
In cases when root tasks processed after ordinary tasks, these ordinary tasks could be not found, because they are not properly merged in root tasks _subTasks property.