### PR TITLE
singletone bz instance is not created in cli mode

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,3 +1,9 @@
-var Beelzebub  = require('../index.js');
+var path = require('path');
+try {
+  var Beelzebub  = require(path.join(process.cwd(), 'node_modules/beelzebub'));
+}
+catch(e) {
+  throw Error('Beelzebub should be installed both locally and globally');
+}
 var cli = new Beelzebub.CLI();
 cli.run();

--- a/lib/bzCLI.js
+++ b/lib/bzCLI.js
@@ -6,7 +6,6 @@ const yargs = require('yargs');
 const when  = require('when');
 
 const manifest  = require('../package.json');
-const Beelzebub = require('./beelzebub.js');
 
 class BzCLI {
     run (config, args) {
@@ -14,7 +13,7 @@ class BzCLI {
         let runTasks = [];
         let promise = when.resolve();
         const currentDir = process.cwd();
-        const bz = new Beelzebub(config || { verbose: true });
+        const bz = require('./index.js')(config || { verbose: true });
 
         if (!args) {
             // remove the first two array items


### PR DESCRIPTION
in bzTasks.js:
```
class BzTasks {
  constructor (config) {
    this.beelzebub = config.beelzebub || util.beelzebubInst;

```
When creating new task instance, `util.beelzebubInst` is empty. This problem occurs only when we use bz cli.

And also if we run globally installed bz, it's creating its own instance, and bz tasks trying to use local one.
